### PR TITLE
당직 관련 GET 요청 응답에 "type": "당직" 추가 #50

### DIFF
--- a/src/main/java/com/toy4/domain/dayOffHistory/repository/DayOffHistoryRepository.java
+++ b/src/main/java/com/toy4/domain/dayOffHistory/repository/DayOffHistoryRepository.java
@@ -33,7 +33,7 @@ public interface DayOffHistoryRepository extends JpaRepository<DayOffHistory, Lo
     @Query("SELECT s FROM DayOffHistory  s " +
         "WHERE s.employee.id = :employeeId " +
         "AND :date BETWEEN s.startDate AND s.endDate " +
-        "AND s.status IN ( :#{T(com.toy4.domain.schedule.RequestStatus).REQUESTED}, :#{T(com.toy4.domain.schedule.RequestStatus).ACCEPTED} )" +
+        "AND s.status IN ( :#{T(com.toy4.domain.schedule.RequestStatus).REQUESTED}, :#{T(com.toy4.domain.schedule.RequestStatus).APPROVED} )" +
         "AND s.dayOff.type IN ( :#{T(com.toy4.domain.dayoff.type.DayOffType).NORMAL_DAY_OFF}, :#{T(com.toy4.domain.dayoff.type.DayOffType).SPECIAL_DAY_OFF})")
     Optional<DayOffHistory> findOverlappedDate(Long employeeId, LocalDate date);
 }

--- a/src/main/java/com/toy4/domain/dayOffHistory/service/impl/DayOffHistoryServiceImpl.java
+++ b/src/main/java/com/toy4/domain/dayOffHistory/service/impl/DayOffHistoryServiceImpl.java
@@ -40,7 +40,7 @@ public class DayOffHistoryServiceImpl implements DayOffHistoryService {
 			.orElseThrow(() -> new EmployeeException(ErrorCode.ENTITY_NOT_FOUND));
 
 		List<DayOffHistory> approveDayOffs = dayOffHistoryRepository.findByEmployeeIdAndStatus(employee.getId(),
-			RequestStatus.ACCEPTED);
+			RequestStatus.APPROVED);
 
 		if (approveDayOffs.isEmpty()) {
 			return responseService.failure(ErrorCode.EMPLOYEE_APPROVED_DAY_OFF_NOT_FOUND);
@@ -79,7 +79,7 @@ public class DayOffHistoryServiceImpl implements DayOffHistoryService {
 		dayOffHistory.updateStatusDayOff(dto);
 		dayOffHistoryRepository.save(dayOffHistory);
 
-		if (dayOffHistory.getStatus() == RequestStatus.ACCEPTED) {
+		if (dayOffHistory.getStatus() == RequestStatus.APPROVED) {
 
 			float totalAmount = dayOffHistory.getTotalAmount();
 

--- a/src/main/java/com/toy4/domain/dutyHistory/controller/DutyHistoryAdminController.java
+++ b/src/main/java/com/toy4/domain/dutyHistory/controller/DutyHistoryAdminController.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/api/admin/duty")
+@RequestMapping("/api/admin/duties")
 @RequiredArgsConstructor
 @RestController
 public class DutyHistoryAdminController {

--- a/src/main/java/com/toy4/domain/dutyHistory/dto/ApprovedDutyResponse.java
+++ b/src/main/java/com/toy4/domain/dutyHistory/dto/ApprovedDutyResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 public class ApprovedDutyResponse {
 	private Long dutyId;
+	private final String type = "당직";
 	private String  requestDate;
 	private String date;
 	private String status;

--- a/src/main/java/com/toy4/domain/dutyHistory/dto/DutyHistoriesResponse.java
+++ b/src/main/java/com/toy4/domain/dutyHistory/dto/DutyHistoriesResponse.java
@@ -16,6 +16,7 @@ public class DutyHistoriesResponse {
 	private String hireDate;
 	private String requestDate;
 	private Long dutyId;
+	private final String type = "당직";
 	private String date;
 	private String status;
 

--- a/src/main/java/com/toy4/domain/dutyHistory/dto/FindDutyHistoryResponse.java
+++ b/src/main/java/com/toy4/domain/dutyHistory/dto/FindDutyHistoryResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class FindDutyHistoryResponse {
 
     private final Long dutyId;
+    private final String type = "당직";
     private final String status;
     private final String date;
     private final String reason;

--- a/src/main/java/com/toy4/domain/dutyHistory/repository/DutyHistoryRepository.java
+++ b/src/main/java/com/toy4/domain/dutyHistory/repository/DutyHistoryRepository.java
@@ -13,11 +13,8 @@ import java.util.Optional;
 
 @Repository
 public interface DutyHistoryRepository extends JpaRepository<DutyHistory, Long> {
+
     List<DutyHistory> findByEmployeeId(Long employeeId);
-    @Query("SELECT s FROM DutyHistory s " +
-            "WHERE s.employee.id = :employeeId " +
-            "AND s.date BETWEEN :startDate AND :endDate")
-    List<DutyHistory> findByEmployeeIdAndDateRange(Long employeeId, LocalDate startDate, LocalDate endDate);
 
     @Query("SELECT s FROM DutyHistory s " +
         "WHERE s.employee.id = :employeeId " +
@@ -25,6 +22,7 @@ public interface DutyHistoryRepository extends JpaRepository<DutyHistory, Long> 
     List<DutyHistory> findByEmployeeIdAndStatus(Long employeeId, RequestStatus status);
 
     List<DutyHistory> findAll();
+
     Optional<DutyHistory> findById(Long id);
 
     @Query("SELECT s FROM DutyHistory s " +

--- a/src/main/java/com/toy4/domain/dutyHistory/service/DutyHistoryService.java
+++ b/src/main/java/com/toy4/domain/dutyHistory/service/DutyHistoryService.java
@@ -4,8 +4,8 @@ import com.toy4.domain.dutyHistory.dto.DutyHistoryDto;
 import com.toy4.global.response.dto.CommonResponse;
 
 public interface DutyHistoryService {
+
 	CommonResponse<?> getEmployeeApprovedDuty(Long employeeId);
 	CommonResponse<?> getDutyHistories();
-
 	CommonResponse<?> updateStatusDuty(DutyHistoryDto dto);
 }

--- a/src/main/java/com/toy4/domain/dutyHistory/service/impl/DutyHistoryServiceImpl.java
+++ b/src/main/java/com/toy4/domain/dutyHistory/service/impl/DutyHistoryServiceImpl.java
@@ -40,7 +40,7 @@ public class DutyHistoryServiceImpl implements DutyHistoryService {
 			.orElseThrow(() -> new EmployeeException(ErrorCode.ENTITY_NOT_FOUND));
 
 		List<DutyHistory> approveDuties = dutyHistoryRepository.findByEmployeeIdAndStatus(employee.getId(),
-			RequestStatus.ACCEPTED);
+			RequestStatus.APPROVED);
 
 		if (approveDuties.isEmpty()) {
 			return responseService.failure(ErrorCode.EMPLOYEE_APPROVED_DUTY_NOT_FOUND);

--- a/src/main/java/com/toy4/domain/employee/controller/EmployeeAdminController.java
+++ b/src/main/java/com/toy4/domain/employee/controller/EmployeeAdminController.java
@@ -14,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
 @RestController
-public class EmployeeController {
+public class EmployeeAdminController {
 
 	private final EmployeeService employeeService;
 	private final DayOffHistoryService dayOffHistoryService;

--- a/src/main/java/com/toy4/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/com/toy4/domain/employee/controller/EmployeeController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
-@RequestMapping("api/admin")
+@RequestMapping("/api/admin")
 @RestController
 public class EmployeeController {
 
@@ -40,7 +40,6 @@ public class EmployeeController {
 		CommonResponse<?> response = employeeService.updateEmployeeInfo(EmployeeInfoRequest.to(employeeInfoRequest), profile);
 		return ResponseEntity.ok(response);
 	}
-
 
 	@GetMapping("/employees/{employeeId}/day-offs")
 	public ResponseEntity<?> getEmployeeApprovedDayOff(@PathVariable Long employeeId) {

--- a/src/main/java/com/toy4/domain/schedule/RequestStatus.java
+++ b/src/main/java/com/toy4/domain/schedule/RequestStatus.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public enum RequestStatus {
     REQUESTED("요청됨"),
     CANCELLED("취소됨"),
-    ACCEPTED("승인됨"),
+    APPROVED("승인됨"),
     REJECTED("거절됨")
     ;
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -52,9 +52,13 @@ VALUES
 INSERT INTO day_off_history(employee_id, day_off_id, status, start_date, end_date, total_amount, reason)
 VALUES
     (1, 1, 'REQUESTED', '2023-07-31', '2023-07-31', 0.5, '늦잠 잘래요.'),
-    (1, 3, 'REQUESTED', '2023-08-01', '2023-08-03', 3, '놀래요.');
+    (1, 3, 'REQUESTED', '2023-08-01', '2023-08-03', 3, '놀래요.'),
+    (1, 1, 'APPROVED', '2023-07-21', '2023-08-21', 0.5, '늦잠 잘래요.'),
+    (1, 3, 'CANCELLED', '2023-08-23', '2023-08-25', 3, '놀래요.');
 
 INSERT INTO duty_history(employee_id, status, date, reason)
 VALUES
     (1, 'REQUESTED', '2023-08-09', '서버 점검.'),
-    (1, 'REQUESTED', '2023-08-10', '프로젝트 마감.');
+    (1, 'REQUESTED', '2023-08-10', '프로젝트 마감.'),
+    (1, 'APPROVED', '2023-08-18', '서버 점검.'),
+    (1, 'CANCELLED', '2023-08-25', '프로젝트 마감.');


### PR DESCRIPTION
### 관련 API
- GET /api/admin/duties
- GET /api/admin/employees/{employeeId}/duties
- GET /api/schedules

### 수정 내용
- 당직 응답 객체에 String type = "당직"을 추가했습니다.
- api 수정 및 자잘한 reformatting 도 수행했습니다.