### PR TITLE
fix: 유저의 연차 목록 조회 시 일반 유저만으로 한정 (#128)

### DIFF
--- a/src/main/java/com/toy4/domain/dayOffHistory/repository/info/DayOffHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/toy4/domain/dayOffHistory/repository/info/DayOffHistoryCustomRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.toy4.domain.dayOffHistory.repository.info;
 
 import java.util.List;
 import javax.persistence.EntityManager;
+
+import com.toy4.domain.employee.type.EmployeeRole;
 import org.springframework.stereotype.Repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
@@ -50,6 +52,7 @@ public class DayOffHistoryCustomRepositoryImpl implements DayOffHistoryCustomRep
 				employee.id.eq(dayOffHistory.employee.id)
 					.and(dayOffHistory.status.in(RequestStatus.REQUESTED, RequestStatus.APPROVED))
 			)
+			.where(employee.role.eq(EmployeeRole.USER))
 			.groupBy(employee.id, employee.name, employee.dayOffRemains)
 			.fetch();
 	}

--- a/src/main/java/com/toy4/global/interceptor/LogInterceptor.java
+++ b/src/main/java/com/toy4/global/interceptor/LogInterceptor.java
@@ -5,7 +5,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.UUID;
 
 @Slf4j
 public class LogInterceptor implements HandlerInterceptor {
@@ -15,9 +14,7 @@ public class LogInterceptor implements HandlerInterceptor {
         String scheme = request.getScheme();
         String method = request.getMethod();
         String requestURI = request.getRequestURI();
-        String logId = UUID.randomUUID().toString();
-        request.setAttribute("logId", logId);
-        log.info("[STT_{}] {} {} {}", logId, scheme, method, requestURI);
+        log.info("[START] {} {} {}", scheme, method, requestURI);
         return true;
     }
 
@@ -26,7 +23,6 @@ public class LogInterceptor implements HandlerInterceptor {
         String scheme = request.getScheme();
         String method = request.getMethod();
         String requestURI = request.getRequestURI();
-        String logId = (String) request.getAttribute("logId");
-        log.info("[END_{}] {} {} {}", logId, scheme, method, requestURI);
+        log.info("[  END] {} {} {}", scheme, method, requestURI);
     }
 }

--- a/src/test/java/com/toy4/domain/dayOffHistory/service/DayOffHistoryMainServiceTest.java
+++ b/src/test/java/com/toy4/domain/dayOffHistory/service/DayOffHistoryMainServiceTest.java
@@ -58,8 +58,8 @@ class DayOffHistoryMainServiceTest {
     @DisplayName("[예외] 종료 날짜가 시작 날짜보다 빠른 경우")
     @Test
     void whenNegativeDaysDifference_thenThrowDayOffExceptionWith_INVERTED_DAY_OFF_RANGE() {
-        when(mockDto.getStartDate()).thenReturn(LocalDate.of(2023, 7, 23));
-        when(mockDto.getEndDate()).thenReturn(LocalDate.of(2023, 7, 22));
+        when(mockDto.getStartDate()).thenReturn(LocalDate.now().plusDays(2));
+        when(mockDto.getEndDate()).thenReturn(LocalDate.now().plusDays(1));
 
         Arrays.stream(DayOffType.values())
                 .forEach(type -> assertThrowWithErrorCode(type, ErrorCode.INVERTED_DAY_OFF_RANGE));
@@ -68,8 +68,8 @@ class DayOffHistoryMainServiceTest {
     @DisplayName("[예외] 시작과 끝 날짜가 다른 반차")
     @Test
     void whenHalfDayOffWithRangedStartEnd_thenThrowDayOffExceptionWith_RANGED_HALF_DAY_OFF() {
-        when(mockDto.getStartDate()).thenReturn(LocalDate.of(2023, 7, 23));
-        when(mockDto.getEndDate()).thenReturn(LocalDate.of(2023, 7, 24));
+        when(mockDto.getStartDate()).thenReturn(LocalDate.now().plusDays(1));
+        when(mockDto.getEndDate()).thenReturn(LocalDate.now().plusDays(2));
 
         Arrays.stream(DayOffType.values())
                 .filter(DayOffType::isHalfDayOff)
@@ -79,8 +79,8 @@ class DayOffHistoryMainServiceTest {
     @DisplayName("[예외] 직원이 없는 경우")
     @Test
     void whenNotFoundEmployee_thenThrowDayOffExceptionWith_EMPLOYEE_NOT_FOUND() {
-        when(mockDto.getStartDate()).thenReturn(LocalDate.of(2023, 7, 23));
-        when(mockDto.getEndDate()).thenReturn(LocalDate.of(2023, 7, 23));
+        when(mockDto.getStartDate()).thenReturn(LocalDate.now());
+        when(mockDto.getEndDate()).thenReturn(LocalDate.now());
         when(mockDto.getEmployeeId()).thenReturn(10000L);
 
         Arrays.stream(DayOffType.values())
@@ -90,8 +90,8 @@ class DayOffHistoryMainServiceTest {
     @DisplayName("[예외] 잔여 연차수 보다 연차 요청이 큰 경우")
     @Test
     void whenNotFoundEmployee_thenThrowDayOffExceptionWith_DAY_OFF_REMAINS_OVER() {
-        when(mockDto.getStartDate()).thenReturn(LocalDate.of(2023, 7, 1));
-        when(mockDto.getEndDate()).thenReturn(LocalDate.of(2023, 7, 31));
+        when(mockDto.getStartDate()).thenReturn(LocalDate.now());
+        when(mockDto.getEndDate()).thenReturn(LocalDate.now().plusDays(1000L));
         when(mockDto.getEmployeeId()).thenReturn(1L);
 
         Arrays.stream(DayOffType.values())
@@ -120,15 +120,15 @@ class DayOffHistoryMainServiceTest {
     }
 
     private void assertPassWithSameStartEnd(Float dayOffRemains, Predicate<DayOffType> dayOffTypePredicate) {
-        LocalDate date = LocalDate.of(2023, 7, 31);
+        LocalDate date = LocalDate.now();
         assertPass(date, date, dayOffRemains, dayOffTypePredicate);
     }
 
     @DisplayName("[성공] 시작과 끝이 다른 not 반차")
     @Test
     void whenLateEndDateWithNotDayOff_thenPass() {
-        LocalDate start = LocalDate.of(2023, 8, 2);
-        LocalDate end = LocalDate.of(2023, 8, 4);
+        LocalDate start = LocalDate.now();
+        LocalDate end = LocalDate.now().plusDays(2);
         assertPass(start, end, 3.0f, type -> !type.isHalfDayOff());
     }
 


### PR DESCRIPTION
- 로깅 시 UUID 출력하지 않도록 삭제 리팩토링 (스프링 로깅 패턴에 요청별 ID 포함됨)
- 실패 테스트 수정